### PR TITLE
Fix Twitter handle of the e-Money project

### DIFF
--- a/data/posts-manifest.js
+++ b/data/posts-manifest.js
@@ -95,7 +95,7 @@ const mapping = [
     links: {
       proof: 'https://e-money.com/documents/e-Money%20Whitepaper.pdf',
       github: 'https://github.com/e-money',
-      twitter: 'https://twitter.com/kiraex',
+      twitter: 'https://twitter.com/emoney_com',
       chat: 'https://t.me/emoney_com',
       website: 'https://e-money.com/',
     },


### PR DESCRIPTION
Thanks for creating the cosmonauts.world website!

I have corrected the Twitter handle of the e-Money project, which was pointing to the handle of the Kira exchange project.